### PR TITLE
Add Spec.primaryInstanceType to ResourcePoolConfig

### DIFF
--- a/api/resourcepool/v1/types.go
+++ b/api/resourcepool/v1/types.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -94,6 +94,9 @@ type ResourcePoolSpec struct {
 
 	// [DEPRECATED] Resource demand fulfillment report.
 	Status ResourceDemandStatus `json:"resourceDemandStatus"`
+
+	// Primary instance type for the resource pool.
+	PrimaryInstanceType string `json:"primaryInstanceType"`
 }
 
 type ResourcePoolStatus struct {


### PR DESCRIPTION
This field will be used to locate which server groups should be treated as primary in case we need to fallback to using other instance types for addressing ICE errors.